### PR TITLE
Fixed flaky test testDateHandling in TimestampsParquetReaderTest.java with JSONAssert

### DIFF
--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -194,17 +194,6 @@
           <version>${hadoop.compile.version}</version>
           <scope>runtime</scope>
         </dependency>
-        <dependency>
-          <groupId>org.json</groupId>
-          <artifactId>json</artifactId>
-          <version>20210307</version>
-        </dependency>
-        <dependency>
-          <groupId>org.skyscreamer</groupId>
-          <artifactId>jsonassert</artifactId>
-          <version>1.5.1</version>
-          <scope>test</scope>
-        </dependency>
       </dependencies>
       <properties>
         <parquet.version>1.13.0</parquet.version>

--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -194,6 +194,17 @@
           <version>${hadoop.compile.version}</version>
           <scope>runtime</scope>
         </dependency>
+        <dependency>
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+          <version>20210307</version>
+        </dependency>
+        <dependency>
+          <groupId>org.skyscreamer</groupId>
+          <artifactId>jsonassert</artifactId>
+          <version>1.5.1</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
       <properties>
         <parquet.version>1.13.0</parquet.version>

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -28,14 +28,13 @@ import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 import java.util.List;
-
-import org.json.JSONException;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * Duplicate of {@link TimestampsParquetInputTest} but for {@link ParquetReader} instead of Hadoop
@@ -95,10 +94,11 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
     try {
-        JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()), false);
-        JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()), false);
-    } catch (JSONException jse) {
-        Assert.fail("Not comparing JSON strings. Error: " + jse.getMessage());
+      JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()), false);
+      JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()), false);
+    } 
+    catch (JSONException jse) {
+      throw new RuntimeException(jse);
     }
   }
 

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -28,10 +29,8 @@ import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
-import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 import java.util.List;
@@ -84,6 +83,8 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
         schemaAsDate,
         JSONPathSpec.DEFAULT
     );
+    ObjectMapper objectMapperString = new ObjectMapper();
+    ObjectMapper objectMapperDate = new ObjectMapper();
     List<InputRowListPlusRawValues> sampledAsString = sampleAllRows(readerAsString);
     List<InputRowListPlusRawValues> sampledAsDate = sampleAllRows(readerAsDate);
     final String expectedJson = "{\n"
@@ -93,13 +94,8 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-    try {
-      JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()), false);
-      JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()), false);
-    } 
-    catch (JSONException jse) {
-      throw new RuntimeException(jse);
-    }
+    Assert.assertEquals(objectMapperString.readTree(expectedJson), objectMapperString.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues())));
+    Assert.assertEquals(objectMapperDate.readTree(expectedJson), objectMapperDate.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues())));
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -94,11 +94,11 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-    try{
+    try {
         JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()), false);
         JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()), false);
-    } catch (JSONException jse){
-        Assert.fail("Not comparing JSON strings");
+    } catch (JSONException jse) {
+        Assert.fail("Not comparing JSON strings. Error: " + jse.getMessage());
     }
   }
 

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -34,6 +34,9 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+
 /**
  * Duplicate of {@link TimestampsParquetInputTest} but for {@link ParquetReader} instead of Hadoop
  */
@@ -91,8 +94,12 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()));
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()));
+    try{
+        JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()), false);
+        JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()), false);
+    } catch (JSONException jse){
+        Assert.fail("Not comparing JSON strings");
+    }
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed flaky test testDateHandling in TimestampsParquetReaderTest.java with JSONAssert


Location: `extensions-core/parquet-extensions`
Filename: `TimestampsParquetReaderTest.java`
Test: `testDateHandling`

1. Test Overview:
In the `TimestampsParquetReaderTest.testDateHandling` test, we assess how timestamps are handled in Parquet files, focusing on date values stored as `strings` and `date objects`. The test checks the consistency of timestamp conversion and verifies that the JSON representations of these timestamps match the expected values.

2. Reason of flakiness:
However, a potential problem arises because the data reading methods used `createReader()` does not always retrieve data in a consistent order, possibly introducing randomness. This can lead to different JSON representations of the same data during test runs.

3. Changes:
- Imported `JSONAssert` and `JSONException` packages, and changed from using standard assertion method `Assert` to using `JSONAssert` when comparing two results `sampledAsString` and `sampledAsDate` with `expectedJson`.  
- Add `org.json` and `org.skyscreamer` dependencies to `pom.xml` file in `/parquet-extensions`.

  To address this issue, the PR proposes changing the comparison approach from a standard assertion method `Assert` to using `JSONAssert`. 
  `JSONAssert` method allows for a comparison of data equality without considering the order in which the data is retrieved. This change ensures more reliable and consistent test results across different runs, regardless of variations in data retrieval order.





<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fixed: `TimestampsParquetReaderTest.testDateHandling` test no longer fail when running with the NonDex tool.


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.